### PR TITLE
Refactor duplicate_name_check  and validate_input method

### DIFF
--- a/app/controllers/late_policies_controller.rb
+++ b/app/controllers/late_policies_controller.rb
@@ -181,7 +181,6 @@ class LatePoliciesController < ApplicationController
     end
 
     return valid_penalty, error_message
-
     
   end
 end

--- a/app/controllers/late_policies_controller.rb
+++ b/app/controllers/late_policies_controller.rb
@@ -137,7 +137,7 @@ class LatePoliciesController < ApplicationController
     if existing_late_policy.policy_name != late_policy_params[:policy_name]
       return check_if_policy_name_exists(prefix)
     end
-    
+
     return true, nil
   end
 

--- a/app/controllers/late_policies_controller.rb
+++ b/app/controllers/late_policies_controller.rb
@@ -137,6 +137,7 @@ class LatePoliciesController < ApplicationController
     if existing_late_policy.policy_name != late_policy_params[:policy_name]
       return check_if_policy_name_exists(prefix)
     end
+    
     return true, nil
   end
 

--- a/app/controllers/late_policies_controller.rb
+++ b/app/controllers/late_policies_controller.rb
@@ -181,5 +181,7 @@ class LatePoliciesController < ApplicationController
     end
 
     return valid_penalty, error_message
+
+    
   end
 end

--- a/app/controllers/late_policies_controller.rb
+++ b/app/controllers/late_policies_controller.rb
@@ -53,7 +53,7 @@ class LatePoliciesController < ApplicationController
   # There are few check points before creating a late policy which are written in the if/else statements.
   def create
     # First this function validates the input then save if the input is valid.
-    valid_penalty, error_message = validate_input(late_policy_params,false)
+    valid_penalty, error_message = validate_input(late_policy_params, false)
     if error_message
       flash[:error] = error_message
     end
@@ -133,11 +133,12 @@ class LatePoliciesController < ApplicationController
 
   # This function checks if the policy name already exists or not and returns boolean value for penalty and the error message.
   def check_if_policy_name_exists_on_update(late_policy_object, prefix)
-      existing_late_policy = LatePolicy.find(params[:id])
-      if existing_late_policy.policy_name != late_policy_object[:policy_name]
-        return check_if_policy_name_exists(late_policy_object, prefix)
-      end
-      return true, nil
+    existing_late_policy = LatePolicy.find(params[:id])
+    if existing_late_policy.policy_name != late_policy_object[:policy_name]
+      return check_if_policy_name_exists(late_policy_object, prefix)
+    end
+
+    return true, nil
   end
 
   def check_if_policy_name_exists(late_policy_object, prefix)
@@ -156,7 +157,7 @@ class LatePoliciesController < ApplicationController
 
     prefix = ""
     if is_update
-      prefix =  "Cannot edit the policy. "
+      prefix = 'Cannot edit the policy. '
       valid_penalty, error_message = check_if_policy_name_exists_on_update(late_policy_object, prefix)
     else
       valid_penalty, error_message = check_if_policy_name_exists(late_policy_object, prefix)

--- a/app/controllers/late_policies_controller.rb
+++ b/app/controllers/late_policies_controller.rb
@@ -151,7 +151,6 @@ class LatePoliciesController < ApplicationController
   end
 
   def check_if_policy_exists(prefix)
-    error_message = nil
     if LatePolicy.check_policy_with_same_name(params[:late_policy][:policy_name], instructor_id)
       error_message = prefix + 'A policy with the same name ' + params[:late_policy][:policy_name] + ' already exists.'
       return false, error_message
@@ -187,6 +186,5 @@ class LatePoliciesController < ApplicationController
     end
 
     return valid_penalty, error_message
-    
   end
 end

--- a/app/controllers/late_policies_controller.rb
+++ b/app/controllers/late_policies_controller.rb
@@ -145,19 +145,25 @@ class LatePoliciesController < ApplicationController
     end
 
     if should_check
-      if LatePolicy.check_policy_with_same_name(params[:late_policy][:policy_name], instructor_id)
-        error_message = prefix + 'A policy with the same name ' + params[:late_policy][:policy_name] + ' already exists.'
-        valid_penalty = false
-      end
+      valid_penalty, error_message = check_if_policy_exists(prefix)
     end
     return valid_penalty, error_message
+  end
+
+  def check_if_policy_exists(prefix)
+    error_message = nil
+    if LatePolicy.check_policy_with_same_name(params[:late_policy][:policy_name], instructor_id)
+      error_message = prefix + 'A policy with the same name ' + params[:late_policy][:policy_name] + ' already exists.'
+      return false, error_message
+    end
+    return true, nil
   end
 
   # This function validates the input.
   def validate_input(is_update = false)
     # Validates input for create and update forms
-    max_penalty = params[:late_policy][:max_penalty].to_i
-    penalty_per_unit = params[:late_policy][:penalty_per_unit].to_i
+    max_penalty = late_policy_params[:max_penalty].to_i
+    penalty_per_unit = late_policy_params[:penalty_per_unit].to_i
 
     valid_penalty, error_message = duplicate_name_check(is_update)
     prefix = is_update ? "Cannot edit the policy. " : ""


### PR DESCRIPTION
Issues Worked on:
Refactor the method “duplicate_name_check” such that it doesn’t  violate the Single Responsibility Principle.
Make the validate_input method as “stateless” as possible.

Contributors:
@kalgeekotak99 @aramasw 